### PR TITLE
Fix issues with alphanumerical domains

### DIFF
--- a/overlay/usr/lib/inithooks/bin/domain-controller.py
+++ b/overlay/usr/lib/inithooks/bin/domain-controller.py
@@ -118,10 +118,10 @@ def validate_realm(realm, interactive):
             err = error_msg("All realm segments must be greater than 0 and"
                             " less than 63 characters.",
                             interactive)
-        if not bit.isalpha():
+        if not bit.isalnum():
             open('/root/shiz', 'w').write(bit)
             err = error_msg("All realm segment characters must be"
-                            " alphanumberic.",
+                            " alphanumeric.",
                             interactive)
     if err:
         return err
@@ -135,7 +135,7 @@ def validate_netbios(domain, interactive):
         err = error_msg("Netbios domain (aka workgroup) must be greater than 0"
                         " and less than 15 characters (7+ recommend).",
                         interactive)
-    if not domain.isalpha():
+    if not domain.isalnum():
         err = error_msg("Netbios domain (aka workgroup) must only contain"
                         " alphanumeric characters.",
                         interactive)


### PR DESCRIPTION
Kerberos and Netbios only accepted letters, not alphanumerical values as stated in the error.
Also corrected a small typo in the Kerberos alphanumeric error message.