### PR TITLE
Fix alphanumeric domain error

### DIFF
--- a/overlay/usr/lib/inithooks/bin/domain-controller.py
+++ b/overlay/usr/lib/inithooks/bin/domain-controller.py
@@ -119,7 +119,6 @@ def validate_realm(realm, interactive):
                             " less than 63 characters.",
                             interactive)
         if not bit.isalnum():
-            open('/root/shiz', 'w').write(bit)
             err = error_msg("All realm segment characters must be"
                             " alphanumeric.",
                             interactive)

--- a/overlay/usr/lib/inithooks/bin/domain-controller.py
+++ b/overlay/usr/lib/inithooks/bin/domain-controller.py
@@ -118,10 +118,10 @@ def validate_realm(realm, interactive):
             err = error_msg("All realm segments must be greater than 0 and"
                             " less than 63 characters.",
                             interactive)
-        if not bit.isalpha():
+        if not bit.isalnum():
             open('/root/shiz', 'w').write(bit)
             err = error_msg("All realm segment characters must be"
-                            " alphanumberic.",
+                            " alphanumeric.",
                             interactive)
     if err:
         return err
@@ -135,7 +135,7 @@ def validate_netbios(domain, interactive):
         err = error_msg("Netbios domain (aka workgroup) must be greater than 0"
                         " and less than 15 characters (7+ recommend).",
                         interactive)
-    if not domain.isalpha():
+    if not domain.isalnum():
         err = error_msg("Netbios domain (aka workgroup) must only contain"
                         " alphanumeric characters.",
                         interactive)

--- a/overlay/usr/lib/inithooks/bin/domain-controller.py
+++ b/overlay/usr/lib/inithooks/bin/domain-controller.py
@@ -118,9 +118,9 @@ def validate_realm(realm, interactive):
             err = error_msg("All realm segments must be greater than 0 and"
                             " less than 63 characters.",
                             interactive)
-        if not bit.isalnum():
+        if not bit.isalnum() or not bit[0].isalpha():
             err = error_msg("All realm segment characters must be"
-                            " alphanumeric.",
+                            " alphanumeric and must start with a letter.",
                             interactive)
     if err:
         return err
@@ -134,9 +134,9 @@ def validate_netbios(domain, interactive):
         err = error_msg("Netbios domain (aka workgroup) must be greater than 0"
                         " and less than 15 characters (7+ recommend).",
                         interactive)
-    if not domain.isalnum():
+    if not domain.isalnum() or not domain[0].isalpha():
         err = error_msg("Netbios domain (aka workgroup) must only contain"
-                        " alphanumeric characters.",
+                        " alphanumeric characters and start with a letter.",
                         interactive)
     if err:
         return err


### PR DESCRIPTION
Built on @IzaacJ's work in #18 but added check for each Kerberos realm part and the Netbios name start with a letter. Also removed a debugging line that is no longer needed...

Closes https://github.com/turnkeylinux/tracker/issues/1543